### PR TITLE
JPA-62 Fix

### DIFF
--- a/src/main/java/javax/persistence/spi/PersistenceProviderResolverHolder.java
+++ b/src/main/java/javax/persistence/spi/PersistenceProviderResolverHolder.java
@@ -18,7 +18,7 @@ import java.lang.ref.WeakReference;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Enumeration;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.WeakHashMap;
@@ -126,7 +126,7 @@ public class PersistenceProviderResolverHolder {
 				synchronized ( resolverClasses ) {
 					try {
 						Enumeration<URL> resources = cl.getResources( "META-INF/services/" + PersistenceProvider.class.getName() );
-						Set<String> names = new HashSet<String>();
+						Set<String> names = new LinkedHashSet<String>();
 						while ( resources.hasMoreElements() ) {
 							URL url = resources.nextElement();
 							InputStream is = url.openStream();
@@ -201,7 +201,7 @@ public class PersistenceProviderResolverHolder {
 			private static final Pattern nonCommentPattern = Pattern.compile( "^([^#]+)" );
 
 			private static Set<String> providerNamesFromReader(BufferedReader reader) throws IOException {
-				Set<String> names = new HashSet<String>();
+				Set<String> names = new LinkedHashSet<String>();
 				String line;
 				while ( ( line = reader.readLine() ) != null ) {
 					line = line.trim();

--- a/src/main/java/javax/persistence/spi/PersistenceProviderResolverHolder.java
+++ b/src/main/java/javax/persistence/spi/PersistenceProviderResolverHolder.java
@@ -137,21 +137,20 @@ public class PersistenceProviderResolverHolder {
 								is.close();
 							}
 						}
+						List<WeakReference<Class<? extends PersistenceProvider>>> nonHibernateClasses = new ArrayList<WeakReference<Class<? extends PersistenceProvider>>>();
 						for ( String s : names ) {
 							@SuppressWarnings( "unchecked" )
 							Class<? extends PersistenceProvider> providerClass = (Class<? extends PersistenceProvider>) cl.loadClass( s );
 							WeakReference<Class<? extends PersistenceProvider>> reference
 									= new WeakReference<Class<? extends PersistenceProvider>>(providerClass);
 							//keep Hibernate atop
-							if ( s.endsWith( "HibernatePersistence" ) && resolverClasses.size() > 0 ) {
-								WeakReference<Class<? extends PersistenceProvider>> movedReference = resolverClasses.get( 0 );
-								resolverClasses.add( 0, reference );
-								resolverClasses.add( movedReference );
-							}
-							else {
+							if ( s.startsWith("org.hibernate") ) {
 								resolverClasses.add( reference );
+							} else {
+								nonHibernateClasses.add( reference );
 							}
 						}
+						resolverClasses.addAll( nonHibernateClasses );
 					}
 					catch ( IOException e ) {
 						throw new PersistenceException( e );


### PR DESCRIPTION
These two commits ensure that all Hibernate providers are preferred over other providers, and that the non-deprecated `org.hibernate.jpa.HibernatePersistenceProvider` comes before `org.hibernate.ejb.HibernatePersistence`, since it is declared first in `hibernate-entitymanager.jar/META-INF/services/javax.persistence.spi.PersistenceProvider`.
