### PR TITLE
Corrected typo

### DIFF
--- a/src/main/java/javax/persistence/LockModeType.java
+++ b/src/main/java/javax/persistence/LockModeType.java
@@ -129,7 +129,7 @@ public enum LockModeType {
 
     /**
      *  Synonymous with <code>OPTIMISTIC_FORCE_INCREMENT</code>.
-     *  <code>OPTIMISTIC_FORCE_IMCREMENT</code> is to be preferred for new
+     *  <code>OPTIMISTIC_FORCE_INCREMENT</code> is to be preferred for new
      *  applications.
      *
      */


### PR DESCRIPTION
I was using the javadoc to copy-paste a replacement for WRITE into my code. This typo briefly tripped me up; mostly because the difference between "M" and "N" in the middle of a word is actually quite hard to see.  Here's the fix.